### PR TITLE
Add a new 'Access CiviMonitor' permission.

### DIFF
--- a/README
+++ b/README
@@ -13,6 +13,8 @@ After installing this extension, copy check_civicrm.php to your Nagios server, s
 - /usr/bin/php /usr/lib/nagios/plugins/check_civicrm.php $HOSTADDRESS$ $_HOSTHTTP$ $_HOSTCMS$ $_HOSTSITE_KEY$ $_HOSTAPI_KEY$ version
 and then services for the appropriate host(s) and/or hostgroup(s) that call those commands.
 
+The contact used in the API request must have either "Administer CiviCRM" or "Access CiviMonitor" permissions.
+
 Release Notes
 -------------
 1.3 - fixed bugs in check_civicrm.php

--- a/civimonitor.php
+++ b/civimonitor.php
@@ -125,3 +125,23 @@ function civimonitor_civicrm_caseTypes(&$caseTypes) {
 function civimonitor_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   _civimonitor_civix_civicrm_alterSettingsFolders($metaDataFolders);
 }
+
+/**
+ * Implements hook_civicrm_alterAPIPermissions().
+ */
+function civimonitor_civicrm_permission(&$permissions) {
+  $permissions += array(
+    'access CiviMonitor' => ts('Access CiviMonitor', array('domain' => 'com.aghstrategies.civimonitor')),
+  );
+}
+
+/**
+ * Implements hook_civicrm_alterAPIPermissions().
+ */
+function civimonitor_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
+  $permissions['setting'] = array(
+    'get' => array(
+      'access CiviMonitor',
+    ),
+  );
+}


### PR DESCRIPTION
The 'setting' API currenclty requires 'administer CiviCRM' permissions for the contact. I try to avoid giving that permission to cron jobs. The following PR works around this by creating a new "access CiviMonitor" permission and implements hook_civicrm_alterAPIPermissions() to allow this new permission to do a Setting.get call.

This isn't an ideal solution though, since broader than what the permissions describe (i.e. "access civimonitor" is really: "view all settings"). I just wanted to document my change, and perhaps see how it goes with the possible incoming changes to how core handles alerts? (ex: a new API call for alerts?)
