### PR TITLE
Update README; add 4.6 compatibility

### DIFF
--- a/README
+++ b/README
@@ -2,12 +2,6 @@ This is a CiviCRM extension to make it possible for a Nagios monitoring system t
 - whether CiviCRM is up-to-date
 - how recently cron has run
 
-This relies on a version server to determine if CiviCRM is up-to-date.  As of writing, there is nothing public that can deliver the detailed status for a given version.  For the time being, it's suggested that you set up a site that can accept a version number and retun a JSON array with two items:
-- an exit code of 0, 1, 2, or 3 corresponding to Nagios statuses of OK, Warning, Critical, and Unknown
-- a comment explaining what's going on
-
-An ideal version status site would evaluate both current-version and LTS series, displaying whether a version is up-to-date (return OK), has newer ones available (return Warning), or has a security release (return Critical).
-
 After installing this extension, copy check_civicrm.php to your Nagios server, set up commands calling:
 - /usr/bin/php /usr/lib/nagios/plugins/check_civicrm.php $HOSTADDRESS$ $_HOSTHTTP$ $_HOSTCMS$ $_HOSTSITE_KEY$ $_HOSTAPI_KEY$ cron
 - /usr/bin/php /usr/lib/nagios/plugins/check_civicrm.php $HOSTADDRESS$ $_HOSTHTTP$ $_HOSTCMS$ $_HOSTSITE_KEY$ $_HOSTAPI_KEY$ version

--- a/info.xml
+++ b/info.xml
@@ -17,6 +17,7 @@
   <compatibility>
     <ver>4.4</ver>
     <ver>4.5</ver>
+    <ver>4.6</ver>
   </compatibility>
   <civix>
     <namespace>CRM/Civimonitor</namespace>


### PR DESCRIPTION
I did some 4.6 compatibility testing, and couldn't find any problems against 4.6.0.  Since as extension reviewer I published this for automated distribution tonight, I added 4.6 compatibility so that next time you release, it can show up for 4.6.

I also removed references in the README to there being no source of CiviCRM version data.  Should've probably been 2 PRs, sorry; I can resubmit if you like one but not the other!
