### PR TITLE
Add quotation marks on severity switch case so it works

### DIFF
--- a/check_civicrm.php
+++ b/check_civicrm.php
@@ -221,17 +221,17 @@ switch (strtolower($argv[6])) {
         // future versions of CiviCRM are likely to send severity
         switch ($attrib['name']) {
           // warnings
-          case checkMysqlTime:
+          case "checkMysqlTime":
             $exit = ($exit > 1) ? $exit : 1;
             break;
 
           // critical
-          case checkDebug:
-          case checkOutboundMail:
-          case checkLogFileIsNotAccessible:
-          case checkUploadsAreNotAccessible:
-          case checkDirectoriesAreNotBrowseable:
-          case checkFilesAreNotPresent:
+          case "checkDebug":
+          case "checkOutboundMail":
+          case "checkLogFileIsNotAccessible":
+          case "checkUploadsAreNotAccessible":
+          case "checkDirectoriesAreNotBrowseable":
+          case "checkFilesAreNotPresent":
             $exit = ($exit > 2) ? $exit : 2;
             break;
 


### PR DESCRIPTION
Without the quotation marks, your strings are treated as constants, which doesn't produce the behavior you're expecting - also fills your Nagios notifications with PHP notices if you don't do this!

Jon
