### PR TITLE
small params fix to avoid warnings

### DIFF
--- a/check_civicrm.php
+++ b/check_civicrm.php
@@ -240,6 +240,9 @@ switch (strtolower($argv[6])) {
             $exit = ($exit > 1) ? $exit : 1;
         }
       }
+      if($exit == 0) {
+        array_unshift($message, 'OK');
+      }
       echo implode(' / ', $message);
       exit($exit);
     }

--- a/civimonitor.php
+++ b/civimonitor.php
@@ -17,6 +17,7 @@ function civimonitor_civicrm_cron($jobManager) {
   $params = array(
     'version' => 3,
     'lastCron' => gmdate('U'),
+    'group_name' => 'civimonitor'
   );
   $result = civicrm_api('Setting', 'create', $params);
 }


### PR DESCRIPTION
Without this fix, CiviCRM cron runs were giving me warnings from CRM/Core/BAO/Setting.php:

```
Illegal string offset 'type' Setting.php:613                   [warning]
Illegal string offset 'group_name' Setting.php:516             [warning]
```

After applying this change, warnings went away. Tested on CiviCRM 4.6.14 on Drupal.
